### PR TITLE
add delay before enabling video

### DIFF
--- a/quick-demo/main.qml
+++ b/quick-demo/main.qml
@@ -14,6 +14,24 @@ Window {
 		return "sip:%2@%1".arg(serverID.text).arg(textField1.text)
 	}
 
+	Timer {
+		id: timer
+	}
+
+	// handle case where delay is required after call begins
+	property bool enableUiVideo: false
+	function setVideoActive() {
+		timer.interval = 35;
+		timer.repeat = false;
+		timer.triggered.connect(function () {
+			enableUiVideo = true;
+		})
+		timer.start();
+
+		return
+	}
+
+
     ColumnLayout {
         id: column
         anchors.fill: parent
@@ -154,6 +172,7 @@ Window {
 				
 				Text{
 					text:{
+						enableUiVideo = false
 						switch(core.callcore.callState){
 						case CallCore.CallStateUnknown:
 							return qsTr("未知状态")
@@ -162,6 +181,7 @@ Window {
 						case CallCore.CallStatePausing:
 							return qsTr("通话暂停")
 						case CallCore.CallStateRunning:
+							setVideoActive()
 							return qsTr("正在通话")
 						case CallCore.CallStateEnd:
 							return qsTr("通话结束")
@@ -254,7 +274,7 @@ Window {
                 width: 500
                 height: 500
                 sourceComponent:camera
-                active:core.callcore.callState == CallCore.CallStateRunning
+                active:enableUiVideo
             }
             Loader{
                 id:loader2


### PR DESCRIPTION
这仅供讨论

In my environment when video call comes in to quick-demo it does not show in the UI.  For sure there is call in progress as status is correct (CallCore.CallStateRunning is the status).  Furthermore, remote client displays stream from quick-demo.

In base code for quick-demo loader1.active is directly set by core.callcore.callState.  This pull request adds a small delay.   With this delay the incoming call displays as expected.

1.  This may be an issue specific to my environment.
2. This does not feel like a proper fix.   However, I do not yet know enough about Qt and linphone to say.
3. Although the changes have been tested on my side, this pull request contains modifications made to base version on quick-demo.   I cannot run this without further modifying it to remove hardcoded IP address.

Let me know your thoughts.